### PR TITLE
fix(docker): copy locale messages into build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ FROM dependencies AS with-source
 # Copy all source files and configuration
 COPY src ./src
 COPY public ./public
+COPY messages ./messages
 COPY next.config.ts .
 COPY tsconfig.json .
 COPY tailwind.config.ts .


### PR DESCRIPTION
# AniTrend Pull Request

- [x] You have followed our [**contributing guidelines**](https://github.com/AniTrend/anitrend-webiste/blob/dev/CONTRIBUTING.md)
- [ ] Double checked that your branch is based on `dev` and targets `dev` (where applicable)
- [ ] Pull request has tests (if applicable)
- [ ] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved

## Description

This fixes the Docker build failure in the deploy workflow by copying the `messages/` directory into the build stage before `yarn build` runs. The locale JSON files already existed in the repository, but they were missing from the container filesystem, which caused `next-intl` imports in `src/i18n/request.ts` to fail during webpack compilation.

Verification performed:
- `yarn build`
- `docker build -t anitrend-website:pr1-test .`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (Improves existing functionality)